### PR TITLE
Fix Rancher version is not passed correctly

### DIFF
--- a/rancher-vcluster/rancher-vcluster.yaml
+++ b/rancher-vcluster/rancher-vcluster.yaml
@@ -61,11 +61,11 @@ spec:
           targetNamespace: cattle-system
           repo: https://releases.rancher.com/server-charts/stable/
           chart: rancher
+          version: {{ .Values.rancherVersion }}
           set:
             ingress.tls.source: rancher
             hostname: {{ .Values.hostname }}
             replicas: 1
-            version: {{ .Values.rancherVersion }}
             global.cattle.psp.enabled: "false"
             bootstrapPassword: {{ .Values.bootstrapPassword }}
           helmVersion: v3


### PR DESCRIPTION
We need to pass the version to the HelmChart CR. Passing the version to chart values has no effect and the latest stable version is always installed.