### PR TITLE
update rancher to v2.8.2 and k3s to v1.27

### DIFF
--- a/rancher-vcluster/rancher-vcluster.yaml
+++ b/rancher-vcluster/rancher-vcluster.yaml
@@ -12,15 +12,15 @@ metadata:
     addon.harvesterhci.io/experimental: "true"
 spec:
   enabled: false
-  repo: https://charts.harvesterhci.io
-  version: "v0.15.2"
+  repo: https://charts.loft.sh
+  version: "v0.19.0"
   chart: vcluster
   valuesContent: |-
     hostname: ""
-    rancherVersion: "v2.7.6"
+    rancherVersion: "v2.8.2"
     bootstrapPassword: ""
     vcluster:
-      image: rancher/k3s:v1.25.10-k3s1
+      image: rancher/k3s:v1.27.10-k3s2
     sync:
       ingresses:
         enabled: "true"


### PR DESCRIPTION
PR includes the following changes:
* Update vcluster chart repo to https://charts.loft.sh, we had originally hosted the chart in charts.harvesterhci.io to work around issue: https://github.com/loft-sh/vcluster/issues/1101. This has now been fixed so we can move to upstream loft-sh hosted chart
* Update k3s to v1.27.10
* Update rancher to v2.8.2