### PR TITLE
fix: password format

### DIFF
--- a/rancher-vcluster/rancher-vcluster.yaml
+++ b/rancher-vcluster/rancher-vcluster.yaml
@@ -67,5 +67,5 @@ spec:
             hostname: {{ .Values.hostname }}
             replicas: 1
             global.cattle.psp.enabled: "false"
-            bootstrapPassword: {{ .Values.bootstrapPassword }}
+            bootstrapPassword: {{ .Values.bootstrapPassword | quote }}
           helmVersion: v3


### PR DESCRIPTION
This format should be string, then we will get `--set-string` in password filed while helm installing.

![image](https://github.com/harvester/experimental-addons/assets/6960289/5b900b52-5216-48ca-bc56-8612b7791e59)

Test cases: `123'"` `123'"!@#$` `123'"!@#$-|>>` `123`
