### PR TITLE
increase default memory limit for syncer

### DIFF
--- a/rancher-vcluster/rancher-vcluster.yaml
+++ b/rancher-vcluster/rancher-vcluster.yaml
@@ -24,6 +24,10 @@ spec:
     sync:
       ingresses:
         enabled: "true"
+    syncer:
+      resources:
+        limits:
+          memory: 8Gi    
     init:
       manifestsTemplate: |-
         apiVersion: v1


### PR DESCRIPTION
The default syncer memory limit in the vcluster helmchart is 2Gi.

https://github.com/loft-sh/vcluster/blob/v0.19/charts/k3s/values.yaml#L163

This can be insufficient when rancher is managing a large number of clusters, and that can cause unexpected issues with syncer being restarted due to OOM killed errors.

The PR bumps default memory limit for syncer to 8G which should be suitable for medium sized rancher installations