### PR TITLE
bump rancher and k3s to supported harvester v1.4.0 versions

### DIFF
--- a/rancher-vcluster/rancher-vcluster.yaml
+++ b/rancher-vcluster/rancher-vcluster.yaml
@@ -17,10 +17,10 @@ spec:
   chart: vcluster
   valuesContent: |-
     hostname: ""
-    rancherVersion: "v2.8.2"
+    rancherVersion: "v2.9.3"
     bootstrapPassword: ""
     vcluster:
-      image: rancher/k3s:v1.27.10-k3s2
+      image: rancher/k3s:v1.28.15-k3s1
     sync:
       ingresses:
         enabled: "true"


### PR DESCRIPTION
PR bumps up rancher and k3s versions to supported versions for Harvester v1.4.0

Related to: https://github.com/harvester/harvester/issues/7337