### PR TITLE
harvester-csi-driver-lvm: bump version 0.1.5

### DIFF
--- a/harvester-csi-driver-lvm/harvester-csi-driver-lvm.yaml
+++ b/harvester-csi-driver-lvm/harvester-csi-driver-lvm.yaml
@@ -8,6 +8,6 @@ metadata:
 spec:
   enabled: false
   repo: https://charts.harvesterhci.io
-  version: 0.1.4
+  version: 0.1.5
   chart: harvester-csi-driver-lvm
   valuesContent: ""


### PR DESCRIPTION
    - improve the webhook lifecycle when removing the harvester-csi-driver-lvm

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
The webhook CR was not cleaned up after removing the harvester-csi-driver-lvm

#### Solution:
Improve the webhook CR lifecycle.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/7935

#### Test plan:
See the test plan of above issue

#### Additional documentation or context
