### PR TITLE
bump Rancher version to v2.11.3

### DIFF
--- a/rancher-vcluster/rancher-vcluster.yaml
+++ b/rancher-vcluster/rancher-vcluster.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -17,17 +18,17 @@ spec:
   chart: vcluster
   valuesContent: |-
     hostname: ""
-    rancherVersion: "v2.9.3"
+    rancherVersion: v2.11.3
     bootstrapPassword: ""
     vcluster:
-      image: rancher/k3s:v1.28.15-k3s1
+      image: rancher/k3s:v1.32.3-k3s1
     sync:
       ingresses:
         enabled: "true"
     syncer:
       resources:
         limits:
-          memory: 8Gi    
+          memory: 8Gi
     init:
       manifestsTemplate: |-
         apiVersion: v1
@@ -63,7 +64,7 @@ spec:
           namespace: kube-system
         spec:
           targetNamespace: cattle-system
-          repo: https://releases.rancher.com/server-charts/stable/
+          repo: https://releases.rancher.com/server-charts/latest
           chart: rancher
           version: {{ .Values.rancherVersion }}
           set:


### PR DESCRIPTION
#### Problem:

The Rancher VCluster addon is currently delivered with Rancher v2.9.3. This is not compatible with the latest Harvester, which only supports Rancher v2.11.x

#### Solution:

Bump the Rancher version to v2.11.3, so that the rancher-vcluster addon works with the latest Harvester version.

#### Test plan:

- Install Harvester v1.5.x
- Install Rancher VCluster addon
- Everything should work as expected