### PR TITLE
chore: bump harvester-vm-dhcp-controller chart to 1.5.1

### DIFF
--- a/harvester-vm-dhcp-controller/harvester-vm-dhcp-controller.yaml
+++ b/harvester-vm-dhcp-controller/harvester-vm-dhcp-controller.yaml
@@ -8,6 +8,6 @@ metadata:
 spec:
   enabled: false
   repo: https://charts.harvesterhci.io
-  version: 1.5.0
+  version: 1.5.1
   chart: harvester-vm-dhcp-controller
   valuesContent: ""


### PR DESCRIPTION
Signed-off-by: Zespre Chang <zespre.chang@suse.com>
