### PR TITLE
update vCluster and Rancher

### DIFF
--- a/rancher-vcluster/rancher-vcluster.yaml
+++ b/rancher-vcluster/rancher-vcluster.yaml
@@ -12,65 +12,67 @@ metadata:
   labels:
     addon.harvesterhci.io/experimental: "true"
 spec:
-  enabled: false
+  enabled: true
   repo: https://charts.loft.sh
-  version: "v0.19.0"
+  version: v0.26.0
   chart: vcluster
   valuesContent: |-
-    hostname: ""
-    rancherVersion: v2.11.3
-    bootstrapPassword: ""
-    vcluster:
-      image: rancher/k3s:v1.32.3-k3s1
+    serviceCIDR: 10.53.0.0/16
+    controlPlane:
+      distro:
+        k3s:
+          enabled: true
+          image:
+            tag: v1.33.2-k3s1
     sync:
-      ingresses:
-        enabled: "true"
-    syncer:
-      resources:
-        limits:
-          memory: 8Gi
-    init:
-      manifestsTemplate: |-
-        apiVersion: v1
-        kind: Namespace
-        metadata:
-          name: cattle-system
-        ---
-        apiVersion: v1
-        kind: Namespace
-        metadata:
-          name: cert-manager
-          labels:
-            certmanager.k8s.io/disable-validation: "true"
-        ---
-        apiVersion: helm.cattle.io/v1
-        kind: HelmChart
-        metadata:
-          name: cert-manager
-          namespace: kube-system
-        spec:
-          targetNamespace: cert-manager
-          repo: https://charts.jetstack.io
-          chart: cert-manager
-          version: v1.5.1
-          helmVersion: v3
-          set:
-            installCRDs: "true"
-        ---
-        apiVersion: helm.cattle.io/v1
-        kind: HelmChart
-        metadata:
-          name: rancher
-          namespace: kube-system
-        spec:
-          targetNamespace: cattle-system
-          repo: https://releases.rancher.com/server-charts/latest
-          chart: rancher
-          version: {{ .Values.rancherVersion }}
-          set:
-            ingress.tls.source: rancher
-            hostname: {{ .Values.hostname }}
-            replicas: 1
-            global.cattle.psp.enabled: "false"
-            bootstrapPassword: {{ .Values.bootstrapPassword | quote }}
-          helmVersion: v3
+      toHost:
+        ingresses:
+          enabled: true
+    experimental:
+      deploy:
+        vcluster:
+          manifests: |-
+            apiVersion: v1
+            kind: Namespace
+            metadata:
+              name: cattle-system
+            ---
+            apiVersion: v1
+            kind: Namespace
+            metadata:
+              name: cert-manager
+              labels:
+                certmanager.k8s.io/disable-validation: "true"
+          helm:
+            - chart:
+                name: cert-manager
+                repo: https://charts.jetstack.io
+                version: v1.8.0
+              release:
+                name: cert-manager
+                namespace: cert-manager
+              values: |-
+                installCRDs: true
+
+            - chart:
+                name: rancher
+                repo: https://releases.rancher.com/server-charts/latest
+                version: v2.12.0-rc2
+              release:
+                name: rancher
+                namespace: cattle-system
+              values: |-
+                hostname: rancher.10.115.252.111.sslip.io
+                replicas: 1
+                bootstrapPassword: password1234
+                rancherImage: rancher/rancher
+                ingress:
+                  tls:
+                    source: rancher
+                global:
+                  cattle:
+                    psp:
+                      enabled: "false"
+                extraEnv:
+                  - name: CATTLE_AGENT_IMAGE
+                    value: rancher/rancher-agent


### PR DESCRIPTION
Update vCluster to v0.26.0 since v0.19 is deprecated and has problems figuring out the service CIDR on RKE2 >= v1.33.x

Update Rancher to v2.12.0-rc2


#### Problem:

vCluster v0.19 has a problem figuring out the service CIDR on RKE2 and K3s >= v1.33. This is a problem on Harvester >= v1.6.0
Using vCluster v0.26 at least allows us to explicitly specify the service CIDR, which means using vCluster v0.26 on Harvester >= v1.6.0 is possible.

#### Solution:

Upgrade vCluster version in use in this Addon

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:

#### Additional documentation or context