### PR TITLE
bump vcluster version to v0.30.0

### DIFF
--- a/rancher-vcluster/rancher-vcluster.yaml
+++ b/rancher-vcluster/rancher-vcluster.yaml
@@ -14,63 +14,103 @@ metadata:
 spec:
   enabled: false
   repo: https://charts.loft.sh
-  version: "v0.19.0"
+  version: "v0.30.0"
   chart: vcluster
   valuesContent: |-
-    hostname: ""
-    rancherVersion: v2.11.3
-    bootstrapPassword: ""
-    vcluster:
-      image: rancher/k3s:v1.32.3-k3s1
+    global:
+      hostname: ""
+      rancherVersion: v2.13.0 
+      bootstrapPassword: ""
+
     sync:
-      ingresses:
-        enabled: "true"
-    syncer:
-      resources:
-        limits:
-          memory: 8Gi
-    init:
-      manifestsTemplate: |-
-        apiVersion: v1
-        kind: Namespace
-        metadata:
-          name: cattle-system
-        ---
-        apiVersion: v1
-        kind: Namespace
-        metadata:
-          name: cert-manager
-          labels:
-            certmanager.k8s.io/disable-validation: "true"
-        ---
-        apiVersion: helm.cattle.io/v1
-        kind: HelmChart
-        metadata:
-          name: cert-manager
-          namespace: kube-system
-        spec:
-          targetNamespace: cert-manager
-          repo: https://charts.jetstack.io
-          chart: cert-manager
-          version: v1.5.1
-          helmVersion: v3
-          set:
-            installCRDs: "true"
-        ---
-        apiVersion: helm.cattle.io/v1
-        kind: HelmChart
-        metadata:
-          name: rancher
-          namespace: kube-system
-        spec:
-          targetNamespace: cattle-system
-          repo: https://releases.rancher.com/server-charts/latest
-          chart: rancher
-          version: {{ .Values.rancherVersion }}
-          set:
-            ingress.tls.source: rancher
-            hostname: {{ .Values.hostname }}
-            replicas: 1
-            global.cattle.psp.enabled: "false"
-            bootstrapPassword: {{ .Values.bootstrapPassword | quote }}
-          helmVersion: v3
+      toHost:
+        ingresses:
+          enabled: true
+
+    controlPlane:
+      distro:
+        k3s:
+          enabled: true
+          image:
+            registry: ""
+            repository: "rancher/k3s"
+            tag: "v1.34.2-k3s1"
+          securityContext: {}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 256Mi
+            requests:
+              cpu: 40m
+              memory: 64Mi
+      backingStore:
+        database:
+          embedded:
+            enabled: true
+
+
+      statefulSet:
+        image:
+          registry: "ghcr.io"
+          repository: "loft-sh/vcluster-pro"
+          tag: "0.30.0"
+        resources:
+          # Limits are resource limits for the container
+          limits:
+            ephemeral-storage: 10Gi
+            memory: 4Gi
+          # Requests are minimal resources that will be consumed by the container
+          requests:
+            ephemeral-storage: 1Gi
+            cpu: 200m
+            memory: 256Mi
+
+    experimental:
+      deploy:
+        vcluster:
+          manifestsTemplate: |-
+            apiVersion: v1
+            kind: Namespace
+            metadata:
+              name: cattle-system
+            ---
+            apiVersion: v1
+            kind: Namespace
+            metadata:
+              name: cert-manager
+              labels:
+                certmanager.k8s.io/disable-validation: "true"
+            ---
+            apiVersion: helm.cattle.io/v1
+            kind: HelmChart
+            metadata:
+              name: cert-manager
+              namespace: kube-system
+            spec:
+              targetNamespace: cert-manager
+              repo: https://charts.jetstack.io
+              chart: cert-manager
+              version: v1.5.1
+              helmVersion: v3
+              set:
+                installCRDs: "true"
+            ---
+            apiVersion: helm.cattle.io/v1
+            kind: HelmChart
+            metadata:
+              name: rancher
+              namespace: kube-system
+            spec:
+              targetNamespace: cattle-system
+              repo: https://releases.rancher.com/server-charts/latest
+              chart: rancher
+              version: {{ .Values.global.rancherVersion }}
+              set:
+                ingress.tls.source: rancher
+                hostname: {{ .Values.global.hostname }}
+                replicas: 1
+                global.cattle.psp.enabled: "false"
+                bootstrapPassword: {{ .Values.global.bootstrapPassword }}
+              helmVersion: v3
+
+


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
PR bumps vcluster to v0.30.0 and rancher to v2.12.0

The PR has additional changes to valuesContent to support format of chart used by vcluster 0.30.0

The addon now leverages `global` section in vcluster config to pass values to the `manifestTemplates` being synced to vcluster

Currently a change is needed to harvester to change addon validation rules to ensure `global.hostname` is used for fqdn validation and not just the `hostname` field in valuesContent.

As a result to test with v1.6.0 or v1.7.0-rc* users need to delete the `harvester-validator` validating webhook configuaration

Edit the addon yaml to provide correct values for `global.hostname` and `global.bootstrapPassword`

Under the hood, vcluster parses the values parsed into Config struct

https://github.com/loft-sh/vcluster/blob/v0.30.0/config/config.go#L38-L39

This is then subsequently used to render the manifestTemplates https://github.com/loft-sh/vcluster/blob/v0.30.0/pkg/k8s/k8s.go#L328

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/9102

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
