### PR TITLE
fix: Bump Cert Manager to more recent Supported Release

### DIFF
--- a/rancher-vcluster/rancher-vcluster.yaml
+++ b/rancher-vcluster/rancher-vcluster.yaml
@@ -90,7 +90,7 @@ spec:
               targetNamespace: cert-manager
               repo: https://charts.jetstack.io
               chart: cert-manager
-              version: v1.5.1
+              version: v1.20.0
               helmVersion: v3
               set:
                 installCRDs: "true"


### PR DESCRIPTION
* current cert-manager supported relase is 1.20 for k8s clusters 1.32 -> 1.35
* EOL for 1.20.0 is cert-manager Release 1.22.0, will not be EOL'd until likely months after end of June, as 1.21.0 Release is scheduled June 24th
* https://cert-manager.io/docs/releases/ 

Resolves: fix/bump-cert-manager-to-supported-release
Signed-off-by: Mike Russell <michael.russell@suse.com>

#### Problem:
We are using an End Of Life'd version of Cert Manager, it is no longer a supported release, especially with Rancher deploys we want to make sure that we are using a version of cert-manager that is currently still supported

#### Solution:
Change the default version to a newer version that is supported currently from cert-manager's page

#### Related Issue(s):
N/A

#### Test plan:
1. build a manifest called my-vcluster-deployment-all-in-one.yaml
2. have it look something like the following massive blob wall of yaml:
```yaml
---
apiVersion: v1
kind: Namespace
metadata:
  name: rancher-vcluster
---
apiVersion: harvesterhci.io/v1beta1
kind: Addon
metadata:
  name: rancher-vcluster
  namespace: rancher-vcluster
  labels:
    addon.harvesterhci.io/experimental: "true"
spec:
  enabled: true
  repo: https://charts.loft.sh
  version: "v0.30.0"
  chart: vcluster
  valuesContent: |-
    global:
      hostname: "rancher-vcluster.10.115.252.95.sslip.io"
      rancherVersion: v2.14.0
      bootstrapPassword: "password1234"

    sync:
      toHost:
        ingresses:
          enabled: true

    controlPlane:
      distro:
        k3s:
          enabled: true
          image:
            registry: ""
            repository: "rancher/k3s"
            tag: "v1.35.3-k3s1"
          securityContext: {}
          resources:
            limits:
              cpu: 200m
              memory: 512Mi
            requests:
              cpu: 40m
              memory: 64Mi
      backingStore:
        database:
          embedded:
            enabled: true

      statefulSet:
        image:
          registry: "ghcr.io"
          repository: "loft-sh/vcluster-pro"
          tag: "0.30.0"
        resources:
          # Limits are resource limits for the container
          limits:
            ephemeral-storage: 30Gi
            memory: 6Gi
          # Requests are minimal resources that will be consumed by the container
          requests:
            ephemeral-storage: 1Gi
            cpu: 200m
            memory: 256Mi

    experimental:
      deploy:
        vcluster:
          manifestsTemplate: |-
            apiVersion: v1
            kind: Namespace
            metadata:
              name: cattle-system
            ---
            apiVersion: v1
            kind: Namespace
            metadata:
              name: cert-manager
              labels:
                certmanager.k8s.io/disable-validation: "true"
            ---
            apiVersion: helm.cattle.io/v1
            kind: HelmChart
            metadata:
              name: cert-manager
              namespace: kube-system
            spec:
              targetNamespace: cert-manager
              repo: https://charts.jetstack.io
              chart: cert-manager
              version: v1.20.0
              helmVersion: v3
              set:
                installCRDs: "true"
            ---
            apiVersion: helm.cattle.io/v1
            kind: HelmChart
            metadata:
              name: rancher
              namespace: kube-system
            spec:
              targetNamespace: cattle-system
              repo: https://releases.rancher.com/server-charts/latest
              chart: rancher
              version: {{ .Values.global.rancherVersion }}
              set:
                ingress.tls.source: rancher
                hostname: {{ .Values.global.hostname }}
                replicas: 1
                global.cattle.psp.enabled: "false"
                bootstrapPassword: {{ .Values.global.bootstrapPassword }}
              helmVersion: v3

```
3. apply that w/ your kubeconfig from harvester
4. use vcluster connect to view the cluster as it comes online
5. ensure that you can import the Harvester cluster into Rancher v2.14.0 w/ the Cert-Manager at Version v1.20.0
6. celebrate as we now our actually not using an end of life'd version of cert-manager to handle the certs for Rancher...

#### Additional documentation or context
N/A