### PR TITLE
update rancher-k3k addon to use v1.9.0-dev.1 version of chart

### DIFF
--- a/rancher-k3k/README.md
+++ b/rancher-k3k/README.md
@@ -16,6 +16,7 @@ rancher:
   rancherVersion: "v2.14.0"
   replicas: 1
   bootstrapPassword: "your_secure_password"
+  repo: "rancherChartRepo"
 k3kCluster:
   servers: 1
   version: v1.35.4-k3s1

--- a/rancher-k3k/rancher-k3k.yaml
+++ b/rancher-k3k/rancher-k3k.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   enabled: false
   repo: https://charts.harvesterhci.io
-  version: "v1.9.0-dev.0"
+  version: "1.9.0-dev.1"
   chart: rancher-k3k
   valuesContent: |-
     certManagerVersion: "v1.20.2"


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
PR updates rancher-k3k addon to use v1.9.0.dev.1 version of the chart.
The new version of chart allows users to override `repo` via `valuesContent`
This is needed to allow users to install rancher-prime via k3k.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/9818

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
