### PR TITLE
fix version reference in rancher-k3k addon

### DIFF
--- a/rancher-k3k/README.md
+++ b/rancher-k3k/README.md
@@ -13,7 +13,7 @@ Users can define the rancher version and rancher url via the `valuesContent` sec
 ```
 rancher:
   hostname: "rancher.harvester_vip.sslip.io"
-  rancherVersion: "v2.14.0"
+  version: "v2.14.0"
   replicas: 1
   bootstrapPassword: "your_secure_password"
   repo: "rancherChartRepo"
@@ -27,7 +27,7 @@ The k3k cluster will sync the ingress for the newly deployed rancher to the unde
 
 Users need to ensure that the `hostname` defined for accessing rancher is accessible via a DNS record pointing to the harvester vip.
 
-Updates to `rancherVersion` in the contentValues can be used to trigger rancher upgrades in the rancher installed in k3k.
+Updates to `version` in the contentValues can be used to trigger rancher upgrades in the rancher installed in k3k.
 
 Similar workflow can also be used to trigger k3s upgrades.
 

--- a/rancher-k3k/rancher-k3k.yaml
+++ b/rancher-k3k/rancher-k3k.yaml
@@ -20,7 +20,7 @@ spec:
     certManagerVersion: "v1.20.2"
     rancher:
       hostname: ""
-      rancherVersion: "v2.14.0"
+      version: "v2.14.0"
       replicas: 1
       bootstrapPassword: "password"
     k3kCluster:


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
PR fixes incorrect reference to `rancherVersion` in the valuesContent and readme docs

The correct field is `version` https://github.com/harvester/charts/blob/master/charts/rancher-k3k/values.yaml#L6

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
