### PR TITLE
Bump experimental add-on versions (harvester-csi-driver-lvm, harvester-upgrade-manager, harvester-vm-dhcp-controller) to v1.8.2-rc1

### DIFF
--- a/harvester-csi-driver-lvm/harvester-csi-driver-lvm.yaml
+++ b/harvester-csi-driver-lvm/harvester-csi-driver-lvm.yaml
@@ -8,6 +8,6 @@ metadata:
 spec:
   enabled: false
   repo: https://charts.harvesterhci.io
-  version: 1.8.1
+  version: 1.8.2-rc1
   chart: harvester-csi-driver-lvm
   valuesContent: ""

--- a/harvester-upgrade-manager/harvester-upgrade-manager.yaml
+++ b/harvester-upgrade-manager/harvester-upgrade-manager.yaml
@@ -8,6 +8,6 @@ metadata:
 spec:
   enabled: false
   repo: https://charts.harvesterhci.io
-  version: 1.8.1
+  version: 1.8.2-rc1
   chart: harvester-upgrade-manager
   valuesContent: ""

--- a/harvester-vm-dhcp-controller/harvester-vm-dhcp-controller.yaml
+++ b/harvester-vm-dhcp-controller/harvester-vm-dhcp-controller.yaml
@@ -8,6 +8,6 @@ metadata:
 spec:
   enabled: false
   repo: https://charts.harvesterhci.io
-  version: 1.8.1
+  version: 1.8.2-rc1
   chart: harvester-vm-dhcp-controller
   valuesContent: ""


### PR DESCRIPTION
Bump experimental add-on versions (harvester-csi-driver-lvm, harvester-upgrade-manager, harvester-vm-dhcp-controller) to v1.8.2-rc1.